### PR TITLE
fix(microsoft-learn-mcp-server): fixed charging event names

### DIFF
--- a/microsoft-learn-mcp-server/src/billing.ts
+++ b/microsoft-learn-mcp-server/src/billing.ts
@@ -5,8 +5,9 @@
 import { Actor, log } from 'apify';
 
 const CHARGEABLE_EVENT_NAMES = [
-    'microsoft_learn_search',
-    'microsoft_learn_fetch',
+    'microsoft_docs_search',
+    'microsoft_docs_fetch',
+    'microsoft_code_sample_search',
 ] as const;
 
 type ChargeableRequest = {


### PR DESCRIPTION
@jirispilka :) Probably hallucinated event names from LLMs. This patch I tested several times a and I see it is being charged properly.