### PR TITLE
Fix financial datasets error logs

### DIFF
--- a/financial-datasets-mcp-server/.actor/pay_per_event.json
+++ b/financial-datasets-mcp-server/.actor/pay_per_event.json
@@ -4,52 +4,52 @@
         "eventDescription": "Initial fee for starting the MCP Server Actor",
         "eventPriceUsd": 0.1
     },
-    "get-income-statements": {
+    "get_income_statements": {
         "eventTitle": "Get income statements",
         "eventDescription": "Fee for getting income statements for a company.",
         "eventPriceUsd": 0.01
     },
-    "get-balance-sheets": {
+    "get_balance_sheets": {
         "eventTitle": "Get balance sheets",
         "eventDescription": "Fee for getting balance sheets for a company.",
         "eventPriceUsd": 0.01
     },
-    "get-cash-flow-statements": {
+    "get_cash_flow_statements": {
         "eventTitle": "Get cash flow statements",
         "eventDescription": "Fee for getting cash flow statements for a company.",
         "eventPriceUsd": 0.01
     },
-    "get-current-stock-price": {
+    "get_current_stock_price": {
         "eventTitle": "Get current stock price",
         "eventDescription": "Fee for getting the current / latest price of a company.",
         "eventPriceUsd": 0.01
     },
-    "get-historical-stock-prices": {
+    "get_historical_stock_prices": {
         "eventTitle": "Get historical stock prices",
         "eventDescription": "Fee for getting historical stock prices for a company.",
         "eventPriceUsd": 0.01
     },
-    "get-company-news": {
+    "get_company_news": {
         "eventTitle": "Get company news",
         "eventDescription": "Fee for getting news for a company.",
         "eventPriceUsd": 0.01
     },
-    "get-available-crypto-tickers": {
+    "get_available_crypto_tickers": {
         "eventTitle": "Get available crypto tickers",
         "eventDescription": "Fee for getting all available crypto tickers.",
         "eventPriceUsd": 0.001
     },
-    "get-crypto-prices": {
+    "get_crypto_prices": {
         "eventTitle": "Get crypto prices",
         "eventDescription": "Fee for getting current prices for a crypto currency.",
         "eventPriceUsd": 0.01
     },
-    "get-historical-crypto-prices": {
+    "get_historical_crypto_prices": {
         "eventTitle": "Get historical crypto prices",
         "eventDescription": "Fee for getting historical prices for a crypto currency.",
         "eventPriceUsd": 0.01
     },
-    "get-current-crypto-price": {
+    "get_current_crypto_price": {
         "eventTitle": "Get current crypto price",
         "eventDescription": "Fee for getting the current / latest price of a crypto currency.",
         "eventPriceUsd": 0.01

--- a/financial-datasets-mcp-server/src/const.py
+++ b/financial-datasets-mcp-server/src/const.py
@@ -14,6 +14,7 @@ class ChargeEvents(str, Enum):
 
     # Generic MCP operations (can be used for any MCP server)
     ACTOR_START = 'actor-start'
+    TOOL_CALL = 'tool-call'
 
     # Financial Datasets-specific operations
     GET_INCOME_STATEMENTS = 'get_income_statements'

--- a/financial-datasets-mcp-server/src/mcp_gateway.py
+++ b/financial-datasets-mcp-server/src/mcp_gateway.py
@@ -41,6 +41,13 @@ async def charge_mcp_operation(
     if not event_name:
         return
 
+    # Whitelist of chargeable events
+    whitelisted_events = {member.value for member in ChargeEvents}
+
+    if event_name not in whitelisted_events:
+        logger.warning(f"Unknown charge event '{event_name}'. Skipping charge.")
+        return
+
     try:
         await charge_function(event_name, count)
         logger.info(f'Charged for event: {event_name}')

--- a/financial-datasets-mcp-server/src/mcp_gateway.py
+++ b/financial-datasets-mcp-server/src/mcp_gateway.py
@@ -41,13 +41,6 @@ async def charge_mcp_operation(
     if not event_name:
         return
 
-    # Whitelist of chargeable events
-    whitelisted_events = {member.value for member in ChargeEvents}
-
-    if event_name not in whitelisted_events:
-        logger.warning(f"Unknown charge event '{event_name}'. Skipping charge.")
-        return
-
     try:
         await charge_function(event_name, count)
         logger.info(f'Charged for event: {event_name}')


### PR DESCRIPTION
Recent fixes as I was testing before publishing.

Again hallucinated event names using dash instead of underscores.

There was error log regarding the unknown TOOL_CALL which is weird as it should be used just as a fallback.