### PR TITLE
feat(wolfram-mcp-server): add Wolfram MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ A curated collection of production-ready Model Context Protocol (MCP) servers pu
 | **[National Parks MCP Server](./national-parks/)** | Geographic and park information | [![National Parks MCP Server](https://apify.com/actor-badge?actor=agentify/national-parks-mcp-server)](https://apify.com/agentify/national-parks-mcp-server)       | [KyrieTangSheng](https://github.com/KyrieTangSheng/mcp-server-nationalparks) |
 | **[Context7 MCP Server](./context7-mcp-server/)** | Up-to-date code docs for any programming library | [![Context7 MCP Server](https://apify.com/actor-badge?actor=agentify/context7-mcp-server)](https://apify.com/agentify/context7-mcp-server)                         | [Upstash](https://github.com/upstash/context7) |
 | **[DeepL MCP Server](./deepl-mcp-server/)** | Translation capabilities using the DeepL API | [![DeepL MCP Server](https://apify.com/actor-badge?actor=agentify/deepl-mcp-server)](https://apify.com/agentify/deepl-mcp-server)                                  | [DeepLcom](https://github.com/DeepLcom/deepl-mcp-server) |
+| **[Wolfram MCP Server](./wolfram-mcp-server/)** | Wolfram\|Alpha, Wolfram Language kernel, and Knowledgebase access | [![Wolfram MCP Server](https://apify.com/actor-badge?actor=agentify/wolfram-mcp-server)](https://apify.com/agentify/wolfram-mcp-server) | [Wolfram](https://www.wolfram.com/artificial-intelligence/mcp-service/) |
 
 ## 🙏 Credits
-These are wrappers—original code by: Brave Software, Perplexity AI, Mendable AI, SlideSpeak, Translated, Githejie, Kiwi.com, KyrieTangSheng, Upstash, Financial Datasets, Microsoft, and others.
+These are wrappers—original code by: Brave Software, Perplexity AI, Mendable AI, SlideSpeak, Translated, Githejie, Kiwi.com, KyrieTangSheng, Upstash, Financial Datasets, Microsoft, Wolfram, and others.
 
 🚩 **Claim this MCP server** – If you are the original developer and would like to claim ownership or have any concerns, please write to [ai@apify.com](mailto:ai@apify.com).
 

--- a/deploy_servers.sh
+++ b/deploy_servers.sh
@@ -61,6 +61,7 @@ declare -A SERVERS=(
     ["texttoolkit-mcp-server"]="typescript:"
     ["tomtom-mcp-server"]="typescript:TOMTOM_API_KEY"
     ["winston-mcp-server"]="typescript:"
+    ["wolfram-mcp-server"]="typescript:WOLFRAM_MCP_API_KEY"
 )
 
 # Load .env file

--- a/wolfram-mcp-server/.actor/actor.json
+++ b/wolfram-mcp-server/.actor/actor.json
@@ -3,7 +3,7 @@
     "actorSpecification": 1,
     "name": "wolfram-mcp-server",
     "title": "Wolfram MCP Server",
-    "description": "The Wolfram MCP Service provides immediate consumer-level access to Wolfram's sophisticated computations and trusted knowledgebase.",
+    "description": "The Wolfram MCP Service provides immediate consumer-level access to Wolfram's sophisticated computations and trusted knowledge base.",
     "version": "0.0",
     "buildTag": "latest",
     "usesStandbyMode": true,

--- a/wolfram-mcp-server/.actor/actor.json
+++ b/wolfram-mcp-server/.actor/actor.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://apify.com/schemas/v1/actor.ide.json",
+    "actorSpecification": 1,
+    "name": "wolfram-mcp-server",
+    "title": "Wolfram MCP Server",
+    "description": "The Wolfram MCP Service provides immediate consumer-level access to Wolfram's sophisticated computations and trusted knowledgebase.",
+    "version": "0.0",
+    "buildTag": "latest",
+    "usesStandbyMode": true,
+    "meta": {
+        "templateId": "ts-mcp-proxy"
+    },
+    "input": {
+        "title": "Actor input schema",
+        "description": "This is Actor input schema",
+        "type": "object",
+        "schemaVersion": 1,
+        "properties": {},
+        "required": []
+    },
+    "dockerfile": "../Dockerfile",
+    "webServerMcpPath": "/mcp"
+}

--- a/wolfram-mcp-server/.actor/pay_per_event.json
+++ b/wolfram-mcp-server/.actor/pay_per_event.json
@@ -1,0 +1,32 @@
+{
+    "actor-start": {
+        "eventTitle": "Price for Actor start",
+        "eventDescription": "Flat fee for starting an Actor run.",
+        "eventPriceUsd": 0.1
+    },
+    "tool-request": {
+        "eventTitle": "Price for completing a tool request",
+        "eventDescription": "Flat fee for completing a tool request.",
+        "eventPriceUsd": 0.05
+    },
+    "prompt-request": {
+        "eventTitle": "Price for completing a prompt request",
+        "eventDescription": "Flat fee for completing a prompt request.",
+        "eventPriceUsd": 0.01
+    },
+    "completion-request": {
+        "eventTitle": "Price for completing a completion request",
+        "eventDescription": "Flat fee for completing a completion request.",
+        "eventPriceUsd": 0.001
+    },
+    "resource-request": {
+        "eventTitle": "Price for completing a resource request",
+        "eventDescription": "Flat fee for completing a resource request.",
+        "eventPriceUsd": 0.025
+    },
+    "list-request": {
+        "eventTitle": "Price for completing a list request",
+        "eventDescription": "Flat fee for completing a list request.",
+        "eventPriceUsd": 0.001
+    }
+}

--- a/wolfram-mcp-server/.editorconfig
+++ b/wolfram-mcp-server/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf

--- a/wolfram-mcp-server/.github/workflows/test.yaml
+++ b/wolfram-mcp-server/.github/workflows/test.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+    pull_request:
+    push:
+        branches: [main, master]
+
+jobs:
+    build-and-test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+                  cache: npm
+            - run: npm ci
+            - run: npm run build
+            - run: npm test

--- a/wolfram-mcp-server/.gitignore
+++ b/wolfram-mcp-server/.gitignore
@@ -1,0 +1,14 @@
+# This file tells Git which files shouldn't be added to source control
+
+.idea
+.vscode
+.zed
+storage
+apify_storage
+crawlee_storage
+node_modules
+dist
+tsconfig.tsbuildinfo
+
+# Added by Apify CLI
+.venv

--- a/wolfram-mcp-server/.npmrc
+++ b/wolfram-mcp-server/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=1

--- a/wolfram-mcp-server/.prettierignore
+++ b/wolfram-mcp-server/.prettierignore
@@ -1,0 +1,1 @@
+.prettierignore

--- a/wolfram-mcp-server/.prettierrc
+++ b/wolfram-mcp-server/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "printWidth": 120,
+    "singleQuote": true,
+    "tabWidth": 4
+}

--- a/wolfram-mcp-server/AGENTS.md
+++ b/wolfram-mcp-server/AGENTS.md
@@ -1,0 +1,676 @@
+# Apify Actors Development Guide
+
+Important: Before you begin, fill in the `generatedBy` property in the meta section of `.actor/actor.json`. Replace it with the tool and model you're currently using, such as "Claude Code with Claude Sonnet 4.5". This helps Apify monitor and improve AGENTS.md for specific AI tools and models.
+
+## What are Apify Actors?
+
+- Actors are serverless programs that run in the cloud. They're inspired by the UNIX philosophy - programs that do one thing well and can be easily combined to build complex systems.
+- Actors are programs packaged as Docker images that run in isolated containers
+
+## Core Concepts
+
+- Accept well-defined JSON input
+- Perform isolated tasks (web scraping, automation, data processing)
+- Produce structured JSON output to datasets and/or store data in key-value stores
+- Can run from seconds to hours or even indefinitely
+- Persist state and can be restarted
+
+## Do
+
+- accept well-defined JSON input and produce structured JSON output
+- use Apify SDK (`apify`) for code running ON Apify platform
+- validate input early with proper error handling and fail gracefully
+- use CheerioCrawler for static HTML content (10x faster than browsers)
+- use PlaywrightCrawler only for JavaScript-heavy sites and dynamic content
+- use router pattern (createCheerioRouter/createPlaywrightRouter) for complex crawls
+- implement retry strategies with exponential backoff for failed requests
+- use proper concurrency settings (HTTP: 10-50, Browser: 1-5)
+- set sensible defaults in `.actor/input_schema.json` for all optional fields
+- set up output schema in `.actor/output_schema.json`
+- clean and validate data before pushing to dataset
+- use semantic CSS selectors and fallback strategies for missing elements
+- respect robots.txt, ToS, and implement rate limiting with delays
+- check which tools (cheerio/playwright/crawlee) are installed before applying guidance
+- use `apify/log` package for logging (censors sensitive data)
+- implement readiness probe handler for standby Actors
+- handle the `aborting` event to gracefully shut down when Actor is stopped
+
+## Don't
+
+- do not rely on `Dataset.getInfo()` for final counts on Cloud platform
+- do not use browser crawlers when HTTP/Cheerio works (massive performance gains with HTTP)
+- do not hard code values that should be in input schema or environment variables
+- do not skip input validation or error handling
+- do not overload servers - use appropriate concurrency and delays
+- do not scrape prohibited content or ignore Terms of Service
+- do not store personal/sensitive data unless explicitly permitted
+- do not use deprecated options like `requestHandlerTimeoutMillis` on CheerioCrawler (v3.x)
+- do not use `additionalHttpHeaders` - use `preNavigationHooks` instead
+- do not assume that local storage is persistent or automatically synced to Apify Console - when running locally with `apify run`, the `storage/` directory is local-only and is NOT pushed to the Cloud
+- do not disable standby mode (`usesStandbyMode: false`) without explicit permission
+
+## Logging
+
+- **ALWAYS use the `apify/log` package for logging** - This package contains critical security logic including censoring sensitive data (Apify tokens, API keys, credentials) to prevent accidental exposure in logs
+
+### Available Log Levels in `apify/log`
+
+The Apify log package provides the following methods for logging:
+
+- `log.debug()` - Debug level logs (detailed diagnostic information)
+- `log.info()` - Info level logs (general informational messages)
+- `log.warning()` - Warning level logs (warning messages for potentially problematic situations)
+- `log.warningOnce()` - Warning level logs (same warning message logged only once)
+- `log.error()` - Error level logs (error messages for failures)
+- `log.exception()` - Exception level logs (for exceptions with stack traces)
+- `log.perf()` - Performance level logs (performance metrics and timing information)
+- `log.deprecated()` - Deprecation level logs (warnings about deprecated code)
+- `log.softFail()` - Soft failure logs (non-critical failures that don't stop execution, e.g., input validation errors, skipped items)
+- `log.internal()` - Internal level logs (internal/system messages)
+
+**Best practices:**
+
+- Use `log.debug()` for detailed operation-level diagnostics (inside functions)
+- Use `log.info()` for general informational messages (API requests, successful operations)
+- Use `log.warning()` for potentially problematic situations (validation failures, unexpected states)
+- Use `log.error()` for actual errors and failures
+- Use `log.exception()` for caught exceptions with stack traces
+
+## Graceful Abort Handling
+
+Handle the `aborting` event to terminate the Actor quickly when stopped by user or platform, minimizing costs especially for PPU/PPE+U billing.
+
+```typescript
+import { setTimeout } from 'node:timers/promises';
+
+Actor.on('aborting', async () => {
+    // Persist any state, do any cleanup you need, and terminate the Actor using `await Actor.exit()` explicitly as soon as possible
+    // This will help ensure that the Actor is doing best effort to honor any potential limits on costs of a single run set by the user
+    // Wait 1 second to allow Crawlee/SDK useState and other state persistence operations to complete
+    // This is a temporary workaround until SDK implements proper state persistence in the aborting event
+    await setTimeout(1000);
+    await Actor.exit();
+});
+```
+
+## Standby Mode
+
+- **NEVER disable standby mode (`usesStandbyMode: false`) in `.actor/actor.json` without explicit permission** - Actor Standby mode solves this problem by letting you have the Actor ready in the background, waiting for the incoming HTTP requests. In a sense, the Actor behaves like a real-time web server or standard API server instead of running the logic once to process everything in batch. Always keep `usesStandbyMode: true` unless there is a specific documented reason to disable it
+- **ALWAYS implement readiness probe handler for standby Actors** - Handle the `x-apify-container-server-readiness-probe` header at GET / endpoint to ensure proper Actor lifecycle management
+
+You can recognize a standby Actor by checking the `usesStandbyMode` property in `.actor/actor.json`. Only implement the readiness probe if this property is set to `true`.
+
+### Readiness Probe Implementation Example
+
+```typescript
+// Apify standby readiness probe at root path
+app.get('/', (req: Request, res: Response) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    if (req.headers['x-apify-container-server-readiness-probe']) {
+        res.end('Readiness probe OK\n');
+    } else {
+        res.end('Actor is ready\n');
+    }
+});
+```
+
+Key points:
+
+- Detect the `x-apify-container-server-readiness-probe` header in incoming requests
+- Respond with HTTP 200 status code for both readiness probe and normal requests
+- This enables proper Actor lifecycle management in standby mode
+
+## Commands
+
+```bash
+# Bootstrap & local development
+apify create [name]                    # Create new Actor project from a template
+apify init                             # Initialize Actor in current directory
+apify run                              # Run Actor locally with simulated platform env
+apify run --purge                      # Run after clearing previous local storage
+apify validate-schema                  # Validate .actor/input_schema.json
+
+# Authentication & account
+apify login                            # Authenticate account (token stored in ~/.apify)
+apify logout                           # Remove stored credentials
+apify info                             # Print currently authenticated account info
+
+# Deployment & remote execution
+apify push                             # Deploy Actor to platform per .actor/actor.json
+apify pull <actor>                     # Download Actor code from the platform
+apify call <actor>                     # Execute Actor remotely on the platform
+apify actors build <actor>             # Create a new build of an Actor
+apify runs ls                          # List recent runs
+
+# Discovery (search Apify Store for community Actors)
+apify actors search "<query>" --user-agent <your-agent-name>
+apify actors info <actor>              # Details about a specific Actor
+
+# Secrets (referenced from actor.json via "@mySecret")
+apify secrets add <name> <value>       # Store a secret locally; uploaded on push
+apify secrets ls                       # List stored secret keys
+
+# TypeScript-specific helpers
+apify actor generate-schema-types      # Generate TypeScript types from Actor schemas
+
+# Direct API access
+apify api <endpoint>                   # Authenticated HTTP request to Apify API
+
+# Help
+apify help                             # List all commands
+apify <command> --help                 # Detailed help for a specific command
+```
+
+Note: If no dedicated Actor exists for your target, search Apify Store for community options with `apify actors search "<query>" --user-agent <your-agent-name>` before building from scratch.
+
+Tip: Inside a running Actor, prefer the SDK (`Actor.getInput()`, `Actor.pushData()`, `Actor.setValue()`) over the equivalent `apify actor` runtime subcommands.
+
+## Apify Platform Environment
+
+When the Actor runs on the Apify platform, the API token is automatically available via the `APIFY_TOKEN` environment variable (note: the variable is `APIFY_TOKEN`, not `APIFY_API_TOKEN`). The Apify SDK reads it automatically, so you do not need to pass it explicitly. Locally, run `apify login` once and the SDK will use your stored credentials.
+
+## Safety and Permissions
+
+Allowed without prompt:
+
+- read files with `Actor.getValue()`
+- push data with `Actor.pushData()`
+- set values with `Actor.setValue()`
+- enqueue requests to RequestQueue
+- run locally with `apify run`
+
+Ask first:
+
+- npm/pip package installations
+- apify push (deployment to cloud)
+- proxy configuration changes (requires paid plan)
+- Dockerfile changes affecting builds
+- deleting datasets or key-value stores
+
+## Project Structure
+
+.actor/
+├── actor.json # Actor config: name, version, env vars, runtime settings
+├── input_schema.json # Input validation & Console form definition
+└── output_schema.json # Specifies where an Actor stores its output
+src/
+└── main.js # Actor entry point and orchestrator
+storage/ # Local-only storage for development (NOT synced to Cloud)
+├── datasets/ # Output items (JSON objects)
+├── key_value_stores/ # Files, config, INPUT
+└── request_queues/ # Pending crawl requests
+Dockerfile # Container image definition
+AGENTS.md # AI agent instructions (this file)
+
+## Local vs Cloud Storage
+
+When running locally with `apify run`, the Apify SDK emulates Cloud storage APIs using the local `storage/` directory. This local storage behaves differently from Cloud storage:
+
+- **Local storage is NOT persistent** - The `storage/` directory is meant for local development and testing only. Data stored there (datasets, key-value stores, request queues) exists only on your local disk.
+- **Local storage is NOT automatically pushed to Apify Console** - Running `apify run` does not upload any storage data to the Apify platform. The data stays local.
+- **Each local run may overwrite previous data** - The local `storage/` directory is reused between runs, but this is local-only behavior, not Cloud persistence.
+- **Cloud storage only works when running on Apify platform** - After deploying with `apify push` and running the Actor in the Cloud, storage calls (`Actor.pushData()`, `Actor.setValue()`, etc.) interact with real Apify Cloud storage, which is then visible in the Apify Console.
+- **To verify Actor output, deploy and run in Cloud** - Do not rely on local `storage/` contents as proof that data will appear in the Apify Console. Always test by deploying (`apify push`) and running the Actor on the platform.
+
+## Actor Input Schema
+
+The input schema defines the input parameters for an Actor. It's a JSON object comprising various field types supported by the Apify platform.
+
+### Structure
+
+```json
+{
+    "title": "<INPUT-SCHEMA-TITLE>",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        /* define input fields here */
+    },
+    "required": []
+}
+```
+
+### Example
+
+```json
+{
+    "title": "E-commerce Product Scraper Input",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        "startUrls": {
+            "title": "Start URLs",
+            "type": "array",
+            "description": "URLs to start scraping from (category pages or product pages)",
+            "editor": "requestListSources",
+            "default": [{ "url": "https://example.com/category" }],
+            "prefill": [{ "url": "https://example.com/category" }]
+        },
+        "followVariants": {
+            "title": "Follow Product Variants",
+            "type": "boolean",
+            "description": "Whether to scrape product variants (different colors, sizes)",
+            "default": true
+        },
+        "maxRequestsPerCrawl": {
+            "title": "Max Requests per Crawl",
+            "type": "integer",
+            "description": "Maximum number of pages to scrape (0 = unlimited)",
+            "default": 1000,
+            "minimum": 0
+        },
+        "proxyConfiguration": {
+            "title": "Proxy Configuration",
+            "type": "object",
+            "description": "Proxy settings for anti-bot protection",
+            "editor": "proxy",
+            "default": { "useApifyProxy": false }
+        },
+        "locale": {
+            "title": "Locale",
+            "type": "string",
+            "description": "Language/country code for localized content",
+            "default": "cs",
+            "enum": ["cs", "en", "de", "sk"],
+            "enumTitles": ["Czech", "English", "German", "Slovak"]
+        }
+    },
+    "required": ["startUrls"]
+}
+```
+
+## Actor Output Schema
+
+The Actor output schema builds upon the schemas for the dataset and key-value store. It specifies where an Actor stores its output and defines templates for accessing that output. Apify Console uses these output definitions to display run results.
+
+### Structure
+
+```json
+{
+    "actorOutputSchemaVersion": 1,
+    "title": "<OUTPUT-SCHEMA-TITLE>",
+    "properties": {
+        /* define your outputs here */
+    }
+}
+```
+
+### Example
+
+```json
+{
+    "actorOutputSchemaVersion": 1,
+    "title": "Output schema of the files scraper",
+    "properties": {
+        "files": {
+            "type": "string",
+            "title": "Files",
+            "template": "{{links.apiDefaultKeyValueStoreUrl}}/keys"
+        },
+        "dataset": {
+            "type": "string",
+            "title": "Dataset",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
+        }
+    }
+}
+```
+
+### Output Schema Template Variables
+
+- `links` (object) - Contains quick links to most commonly used URLs
+- `links.publicRunUrl` (string) - Public run url in format `https://console.apify.com/view/runs/:runId`
+- `links.consoleRunUrl` (string) - Console run url in format `https://console.apify.com/actors/runs/:runId`
+- `links.apiRunUrl` (string) - API run url in format `https://api.apify.com/v2/actor-runs/:runId`
+- `links.apiDefaultDatasetUrl` (string) - API url of default dataset in format `https://api.apify.com/v2/datasets/:defaultDatasetId`
+- `links.apiDefaultKeyValueStoreUrl` (string) - API url of default key-value store in format `https://api.apify.com/v2/key-value-stores/:defaultKeyValueStoreId`
+- `links.containerRunUrl` (string) - URL of a webserver running inside the run in format `https://<containerId>.runs.apify.net/`
+- `run` (object) - Contains information about the run same as it is returned from the `GET Run` API endpoint
+- `run.defaultDatasetId` (string) - ID of the default dataset
+- `run.defaultKeyValueStoreId` (string) - ID of the default key-value store
+
+## Dataset Schema Specification
+
+The dataset schema defines how your Actor's output data is structured, transformed, and displayed in the Output tab in the Apify Console.
+
+### Example
+
+Consider an example Actor that calls `Actor.pushData()` to store data into dataset:
+
+```typescript
+import { Actor } from 'apify';
+// Initialize the JavaScript SDK
+await Actor.init();
+
+/**
+ * Actor code
+ */
+await Actor.pushData({
+    numericField: 10,
+    pictureUrl: 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png',
+    linkUrl: 'https://google.com',
+    textField: 'Google',
+    booleanField: true,
+    dateField: new Date(),
+    arrayField: ['#hello', '#world'],
+    objectField: {},
+});
+
+// Exit successfully
+await Actor.exit();
+```
+
+To set up the Actor's output tab UI, reference a dataset schema file in `.actor/actor.json`:
+
+```json
+{
+    "actorSpecification": 1,
+    "name": "book-library-scraper",
+    "title": "Book Library Scraper",
+    "version": "1.0.0",
+    "storages": {
+        "dataset": "./dataset_schema.json"
+    }
+}
+```
+
+Then create the dataset schema in `.actor/dataset_schema.json`:
+
+```json
+{
+    "actorSpecification": 1,
+    "fields": {},
+    "views": {
+        "overview": {
+            "title": "Overview",
+            "transformation": {
+                "fields": [
+                    "pictureUrl",
+                    "linkUrl",
+                    "textField",
+                    "booleanField",
+                    "arrayField",
+                    "objectField",
+                    "dateField",
+                    "numericField"
+                ]
+            },
+            "display": {
+                "component": "table",
+                "properties": {
+                    "pictureUrl": {
+                        "label": "Image",
+                        "format": "image"
+                    },
+                    "linkUrl": {
+                        "label": "Link",
+                        "format": "link"
+                    },
+                    "textField": {
+                        "label": "Text",
+                        "format": "text"
+                    },
+                    "booleanField": {
+                        "label": "Boolean",
+                        "format": "boolean"
+                    },
+                    "arrayField": {
+                        "label": "Array",
+                        "format": "array"
+                    },
+                    "objectField": {
+                        "label": "Object",
+                        "format": "object"
+                    },
+                    "dateField": {
+                        "label": "Date",
+                        "format": "date"
+                    },
+                    "numericField": {
+                        "label": "Number",
+                        "format": "number"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+### Structure
+
+```json
+{
+    "actorSpecification": 1,
+    "fields": {},
+    "views": {
+        "<VIEW_NAME>": {
+            "title": "string (required)",
+            "description": "string (optional)",
+            "transformation": {
+                "fields": ["string (required)"],
+                "unwind": ["string (optional)"],
+                "flatten": ["string (optional)"],
+                "omit": ["string (optional)"],
+                "limit": "integer (optional)",
+                "desc": "boolean (optional)"
+            },
+            "display": {
+                "component": "table (required)",
+                "properties": {
+                    "<FIELD_NAME>": {
+                        "label": "string (optional)",
+                        "format": "text|number|date|link|boolean|image|array|object (optional)"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+**Dataset Schema Properties:**
+
+- `actorSpecification` (integer, required) - Specifies the version of dataset schema structure document (currently only version 1)
+- `fields` (JSONSchema object, required) - Schema of one dataset object (use JsonSchema Draft 2020-12 or compatible)
+- `views` (DatasetView object, required) - Object with API and UI views description
+
+**DatasetView Properties:**
+
+- `title` (string, required) - Visible in UI Output tab and API
+- `description` (string, optional) - Only available in API response
+- `transformation` (ViewTransformation object, required) - Data transformation applied when loading from Dataset API
+- `display` (ViewDisplay object, required) - Output tab UI visualization definition
+
+**ViewTransformation Properties:**
+
+- `fields` (string[], required) - Fields to present in output (order matches column order)
+- `unwind` (string[], optional) - Deconstructs nested children into parent object
+- `flatten` (string[], optional) - Transforms nested object into flat structure
+- `omit` (string[], optional) - Removes specified fields from output
+- `limit` (integer, optional) - Maximum number of results (default: all)
+- `desc` (boolean, optional) - Sort order (true = newest first)
+
+**ViewDisplay Properties:**
+
+- `component` (string, required) - Only `table` is available
+- `properties` (Object, optional) - Keys matching `transformation.fields` with ViewDisplayProperty values
+
+**ViewDisplayProperty Properties:**
+
+- `label` (string, optional) - Table column header
+- `format` (string, optional) - One of: `text`, `number`, `date`, `link`, `boolean`, `image`, `array`, `object`
+
+## Key-Value Store Schema Specification
+
+The key-value store schema organizes keys into logical groups called collections for easier data management.
+
+### Example
+
+Consider an example Actor that calls `Actor.setValue()` to save records into the key-value store:
+
+```typescript
+import { Actor } from 'apify';
+// Initialize the JavaScript SDK
+await Actor.init();
+
+/**
+ * Actor code
+ */
+await Actor.setValue('document-1', 'my text data', { contentType: 'text/plain' });
+
+await Actor.setValue(`image-${imageID}`, imageBuffer, { contentType: 'image/jpeg' });
+
+// Exit successfully
+await Actor.exit();
+```
+
+To configure the key-value store schema, reference a schema file in `.actor/actor.json`:
+
+```json
+{
+    "actorSpecification": 1,
+    "name": "data-collector",
+    "title": "Data Collector",
+    "version": "1.0.0",
+    "storages": {
+        "keyValueStore": "./key_value_store_schema.json"
+    }
+}
+```
+
+Then create the key-value store schema in `.actor/key_value_store_schema.json`:
+
+```json
+{
+    "actorKeyValueStoreSchemaVersion": 1,
+    "title": "Key-Value Store Schema",
+    "collections": {
+        "documents": {
+            "title": "Documents",
+            "description": "Text documents stored by the Actor",
+            "keyPrefix": "document-"
+        },
+        "images": {
+            "title": "Images",
+            "description": "Images stored by the Actor",
+            "keyPrefix": "image-",
+            "contentTypes": ["image/jpeg"]
+        }
+    }
+}
+```
+
+### Structure
+
+```json
+{
+    "actorKeyValueStoreSchemaVersion": 1,
+    "title": "string (required)",
+    "description": "string (optional)",
+    "collections": {
+        "<COLLECTION_NAME>": {
+            "title": "string (required)",
+            "description": "string (optional)",
+            "key": "string (conditional - use key OR keyPrefix)",
+            "keyPrefix": "string (conditional - use key OR keyPrefix)",
+            "contentTypes": ["string (optional)"],
+            "jsonSchema": "object (optional)"
+        }
+    }
+}
+```
+
+**Key-Value Store Schema Properties:**
+
+- `actorKeyValueStoreSchemaVersion` (integer, required) - Version of key-value store schema structure document (currently only version 1)
+- `title` (string, required) - Title of the schema
+- `description` (string, optional) - Description of the schema
+- `collections` (Object, required) - Object where each key is a collection ID and value is a Collection object
+
+**Collection Properties:**
+
+- `title` (string, required) - Collection title shown in UI tabs
+- `description` (string, optional) - Description appearing in UI tooltips
+- `key` (string, conditional) - Single specific key for this collection
+- `keyPrefix` (string, conditional) - Prefix for keys included in this collection
+- `contentTypes` (string[], optional) - Allowed content types for validation
+- `jsonSchema` (object, optional) - JSON Schema Draft 07 format for `application/json` content type validation
+
+Either `key` or `keyPrefix` must be specified for each collection, but not both.
+
+## Actor README
+
+**Always generate a README.md file as part of Actor development.** The README is the Actor's public landing page on Apify Store - it serves as SEO, first impression, documentation, and support page combined.
+
+### Required: Generate README automatically
+
+When building an Actor, always create a `README.md` in the project root. Do not wait for the user to ask for it. The README is a critical part of a complete Actor.
+
+### README structure
+
+Write in Markdown. Use H2 (`##`) for main sections (these become the table of contents) and H3 (`###`) for subsections. Do not use H1 - the Actor name is automatically the H1. Aim for at least 300 words.
+
+Include these sections in order:
+
+1. **What does [Actor name] do?** - 2-3 sentences explaining what it does, what data it extracts, and how to try it. Link to the target website. Mention Apify platform advantages (API access, scheduling, integrations, proxy rotation, monitoring).
+2. **Why use [Actor name]?** - Business use cases and benefits.
+3. **How to use [Actor name]** - Numbered step-by-step tutorial. Keep it simple and reassuring.
+4. **Input** - Describe input fields. Reference the Input tab. Optionally include a screenshot or JSON example of the input schema.
+5. **Output** - Show a simplified JSON output example. Mention "You can download the dataset in various formats such as JSON, HTML, CSV, or Excel."
+6. **Data table** - If the Actor extracts data, include a table of the main data fields it outputs.
+7. **Pricing / Cost estimation** - Set expectations on cost. Mention free tier limits if applicable. Frame as "How much does it cost to scrape [target site]?"
+8. **Tips or Advanced options** - How to optimize runs, limit compute units, improve speed or accuracy.
+9. **FAQ, disclaimers, and support** - Legality disclaimer for scrapers, known limitations, link to Issues tab for feedback, mention custom solution availability.
+
+### README best practices
+
+- Write SEO-friendly headings with relevant keywords (e.g., "How to scrape [site] data" not just "Tutorial")
+- Bold the most important words in the intro
+- The first 25% of the README matters most - front-load the value proposition
+- Match the tone to the target audience: simple language for no-code users, technical details for developers
+- Include a JSON output example showing 1-2 representative items
+- Reference these top Actors for README best practices: https://apify.com/apify/instagram-scraper and https://apify.com/compass/crawler-google-places
+- Embed YouTube video URLs on their own line (Apify Console auto-renders them)
+- Use HTML for image sizing if needed; CSS is not supported
+
+## MCP Tools
+
+### Apify MCP
+
+If the Apify MCP server is configured, use these tools for documentation:
+
+- `search-apify-docs` - Search documentation
+- `fetch-apify-docs` - Get full doc pages
+
+Otherwise, reference: `@https://mcp.apify.com/`
+
+### Playwright MCP (debugging)
+
+The Playwright MCP server is a useful tool for debugging Actors that interact with the web - it lets the agent drive a real browser to inspect pages, capture selectors, and reproduce issues.
+
+Install with the Claude Code CLI:
+
+```bash
+claude mcp add playwright npx @playwright/mcp@latest
+```
+
+Or add it manually to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+## Resources
+
+- [docs.apify.com/llms.txt](https://docs.apify.com/llms.txt) - Quick reference
+- [docs.apify.com/llms-full.txt](https://docs.apify.com/llms-full.txt) - Complete docs
+- [crawlee.dev](https://crawlee.dev) - Crawlee documentation
+- [whitepaper.actor](https://raw.githubusercontent.com/apify/actor-whitepaper/refs/heads/master/README.md) - Complete Actor specification

--- a/wolfram-mcp-server/CLAUDE.md
+++ b/wolfram-mcp-server/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/wolfram-mcp-server/Dockerfile
+++ b/wolfram-mcp-server/Dockerfile
@@ -1,0 +1,56 @@
+# Specify the base Docker image. You can read more about
+# the available images at https://docs.apify.com/sdk/js/docs/guides/docker-images
+# You can also use any other image from Docker Hub.
+FROM apify/actor-node:24 AS builder
+
+# Check preinstalled packages
+RUN npm ls @crawlee/core apify puppeteer playwright
+
+# Copy just package.json and package-lock.json
+# to speed up the build using Docker layer cache.
+COPY --chown=myuser:myuser package*.json ./
+
+# Install all dependencies. Don't audit to speed up the installation.
+RUN npm install --include=dev --audit=false
+
+# Next, copy the source files using the user set
+# in the base image.
+COPY --chown=myuser:myuser . ./
+
+# Install all dependencies and build the project.
+# Don't audit to speed up the installation.
+RUN npm run build
+
+# Create final image
+FROM apify/actor-node:24
+
+# Check preinstalled packages
+RUN npm ls @crawlee/core apify puppeteer playwright
+
+# Copy just package.json and package-lock.json
+# to speed up the build using Docker layer cache.
+COPY --chown=myuser:myuser package*.json ./
+
+# Install NPM packages, skip optional and development dependencies to
+# keep the image small. Avoid logging too much and print the dependency
+# tree for debugging
+RUN npm --quiet set progress=false \
+    && npm install --omit=dev --omit=optional \
+    && echo "Installed NPM packages:" \
+    && (npm list --omit=dev --all || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "NPM version:" \
+    && npm --version \
+    && rm -r ~/.npm
+
+# Copy built JS files from builder image
+COPY --from=builder --chown=myuser:myuser /usr/src/app/dist ./dist
+
+# Next, copy the remaining files and directories with the source code.
+# Since we do this after NPM install, quick build will be really fast
+# for most source file changes.
+COPY --chown=myuser:myuser . ./
+
+# Run the image.
+CMD ["node", "dist/main.js"]

--- a/wolfram-mcp-server/README.md
+++ b/wolfram-mcp-server/README.md
@@ -1,0 +1,64 @@
+## Wolfram MCP Server
+
+The Wolfram MCP Service provides immediate consumer-level access to Wolfram's sophisticated computations and trusted knowledgebase. This Apify Actor exposes Wolfram's hosted MCP service ([wolfram.com/artificial-intelligence/mcp-service](https://www.wolfram.com/artificial-intelligence/mcp-service/)) over a streamable HTTP endpoint so any MCP client can connect via an Apify URL with Bearer auth.
+
+**About this MCP Server:** To understand how to connect to and utilize this MCP server, please refer to the official Model Context Protocol documentation at [mcp.apify.com](https://mcp.apify.com).
+
+## Connection URL
+MCP clients can connect to this server at:
+
+```text
+https://mcp-servers--wolfram-mcp-server.apify.actor/mcp
+```
+
+## Client Configuration
+To connect to this MCP server, use the following configuration in your MCP client:
+
+```json
+{
+  "mcpServers": {
+    "wolfram": {
+      "url": "https://mcp-servers--wolfram-mcp-server.apify.actor/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_APIFY_TOKEN"
+      }
+    }
+  }
+}
+```
+
+**Note:** Replace `YOUR_APIFY_TOKEN` with your actual Apify API token. You can find your token in the [Apify Console](https://console.apify.com/account/integrations).
+
+## 🚩 Claim this MCP server
+All credits to the original authors of https://www.wolfram.com/artificial-intelligence/mcp-service/
+To claim this server, please write to [ai@apify.com](mailto:ai@apify.com).
+
+---
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `WolframContext` | Semantic search over Wolfram resources. Call this first in a new conversation (or whenever the topic shifts) to ground subsequent tool calls with up-to-date relevant information. Input is natural-language context, not a search query. |
+| `WolframLanguageEvaluator` | Evaluate Wolfram Language code in a kernel. Supports symbolic (`Solve[...]`), numerical (`N[Pi, 50]`), and unit-aware (`UnitConvert[...]`) computations. Accepts `\[FreeformPrompt]["..."]` for natural-language input that expands like a macro before evaluation. Optional `timeConstraint` (seconds, default 60). |
+| `WolframAlpha` | Natural-language Wolfram\|Alpha queries for computational answers across chemistry, physics, geography, history, art, astronomy, and more. |
+
+### ✨ Example Usage
+
+#### Symbolic & numerical math
+> "Solve `x^2 + 3x - 4 == 0` for x, then give me the numerical value of `Pi` to 50 digits."
+
+#### Real-world data & units
+> "Convert 100 miles to kilometers, and tell me the current population of Tokyo."
+
+#### Live computational knowledge
+> "What's the distance from Earth to Mars right now, and what's the molecular weight of caffeine?"
+
+## References
+To learn more about Apify and Actors, take a look at the following resources:
+- [Apify SDK for JavaScript documentation](https://docs.apify.com/sdk/js)
+- [Apify SDK for Python documentation](https://docs.apify.com/sdk/python)
+- [Apify Platform documentation](https://docs.apify.com/platform)
+- [Apify MCP Server](https://docs.apify.com/platform/integrations/mcp)
+- [Webinar: Building and Monetizing MCP Servers on Apify](https://www.youtube.com/watch?v=w3AH3jIrXXo)
+- [Join our developer community on Discord](https://discord.com/invite/jyEM2PRvMU)

--- a/wolfram-mcp-server/eslint.config.mjs
+++ b/wolfram-mcp-server/eslint.config.mjs
@@ -1,0 +1,30 @@
+import prettier from 'eslint-config-prettier';
+
+import apify from '@apify/eslint-config/ts.js';
+import globals from 'globals';
+import tsEslint from 'typescript-eslint';
+
+// eslint-disable-next-line import-x/no-default-export
+export default [
+    { ignores: ['**/dist', '**/test', 'eslint.config.mjs'] },
+    ...apify,
+    prettier,
+    {
+        languageOptions: {
+            parser: tsEslint.parser,
+            parserOptions: {
+                project: 'tsconfig.json',
+            },
+            globals: {
+                ...globals.node,
+                ...globals.jest,
+            },
+        },
+        plugins: {
+            '@typescript-eslint': tsEslint.plugin,
+        },
+        rules: {
+            'no-console': 0,
+        },
+    },
+];

--- a/wolfram-mcp-server/package.json
+++ b/wolfram-mcp-server/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "wolfram-mcp-server",
+    "version": "0.0.1",
+    "type": "module",
+    "description": "TypeScript Model Context Protocol server.",
+    "engines": {
+        "node": ">=20.0.0"
+    },
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.5",
+        "mcp-remote": "0.1.38",
+        "apify": "^3.7.0",
+        "body-parser": "^2.2.0",
+        "express": "^5.1.0",
+        "zod": "^3.25.76"
+    },
+    "devDependencies": {
+        "@apify/eslint-config": "^2.0.0",
+        "@apify/tsconfig": "^0.1.1",
+        "@types/body-parser": "^1.19.5",
+        "@types/express": "^5.0.2",
+        "@types/node": "^24.0.0",
+        "eslint": "^9.29.0",
+        "eslint-config-prettier": "^10.1.5",
+        "globals": "^17.0.0",
+        "prettier": "^3.5.3",
+        "tsx": "^4.20.3",
+        "typescript": "^6.0.0",
+        "typescript-eslint": "^8.58.0",
+        "vitest": "^4.1.0"
+    },
+    "scripts": {
+        "start": "npm run start:dev",
+        "start:prod": "node dist/main.js",
+        "start:dev": "tsx src/main.ts",
+        "build": "tsc",
+        "test": "vitest run"
+    },
+    "author": "It's not you it's me",
+    "license": "ISC"
+}

--- a/wolfram-mcp-server/src/billing.ts
+++ b/wolfram-mcp-server/src/billing.ts
@@ -1,0 +1,43 @@
+/**
+ * This module handles billing for different types of protocol requests in the MCP server.
+ * It defines a function to charge users based on the type of protocol method invoked.
+ */
+import { Actor, log } from 'apify';
+
+/**
+ * Charges the user for a message request based on the method type.
+ * Supported method types are mapped to specific billing events.
+ *
+ * @param request - The request object containing the method string.
+ * @returns Promise<void>
+ */
+export async function chargeMessageRequest(request: { method: string }): Promise<void> {
+    const { method } = request;
+
+    // See https://modelcontextprotocol.io/specification/2025-06-18/server for more details
+    // on the method names and protocol messages
+    // Charge for list requests (e.g., tools/list, resources/list, etc.)
+    if (method.endsWith('/list')) {
+        await Actor.charge({ eventName: 'list-request' });
+        log.info(`Charged for list request: ${method}`);
+        // Charge for tool-related requests
+    } else if (method.startsWith('tools/')) {
+        await Actor.charge({ eventName: 'tool-request' });
+        log.info(`Charged for tool request: ${method}`);
+        // Charge for resource-related requests
+    } else if (method.startsWith('resources/')) {
+        await Actor.charge({ eventName: 'resource-request' });
+        log.info(`Charged for resource request: ${method}`);
+        // Charge for prompt-related requests
+    } else if (method.startsWith('prompts/')) {
+        await Actor.charge({ eventName: 'prompt-request' });
+        log.info(`Charged for prompt request: ${method}`);
+        // Charge for completion-related requests
+    } else if (method.startsWith('completion/')) {
+        await Actor.charge({ eventName: 'completion-request' });
+        log.info(`Charged for completion request: ${method}`);
+        // Do not charge for other methods
+    } else {
+        log.info(`Not charging for method: ${method}`);
+    }
+}

--- a/wolfram-mcp-server/src/main.ts
+++ b/wolfram-mcp-server/src/main.ts
@@ -1,0 +1,57 @@
+/**
+ * MCP Server - Main Entry Point
+ *
+ * This file serves as the entry point for the MCP Server Actor.
+ * It sets up a proxy server that forwards requests to the locally running
+ * MCP server, which provides a Model Context Protocol (MCP) interface.
+ */
+
+// Apify SDK - toolkit for building Apify Actors (Read more at https://docs.apify.com/sdk/js/)
+import { Actor, log } from 'apify';
+
+import { startServer } from './server.js';
+
+// This is an ESM project, and as such, it requires you to specify extensions in your relative imports
+// Read more about this here: https://nodejs.org/docs/latest-v18.x/api/esm.html#mandatory-file-extensions
+// Note that we need to use `.js` even when inside TS files
+// import { router } from './routes.js';
+
+const WOLFRAM_MCP_API_KEY = process.env.WOLFRAM_MCP_API_KEY;
+if (!WOLFRAM_MCP_API_KEY) {
+    const msg = 'WOLFRAM_MCP_API_KEY env var is required to run this Actor! Set the value in the Environment variables Actor settings and rebuild the Actor.';
+    log.error(msg);
+    await Actor.exit({ statusMessage: msg });
+}
+
+// Configuration constants for the MCP server
+// Command to run the Everything MCP Server
+const MCP_COMMAND = [
+    'npx',
+    'mcp-remote',
+    'https://services.wolfram.com/api/mcp',
+    '--header',
+    `Authorization: Bearer ${WOLFRAM_MCP_API_KEY}`,
+];
+
+// Check if the Actor is running in standby mode
+const STANDBY_MODE = process.env.APIFY_META_ORIGIN === 'STANDBY';
+const SERVER_PORT = parseInt(process.env.ACTOR_WEB_SERVER_PORT || '3001', 10);
+
+// Initialize the Apify Actor environment
+// The init() call configures the Actor to correctly work with the Apify-provided environment - mainly the storage infrastructure. It is necessary that every Actor performs an init() call.
+await Actor.init();
+
+// Charge for Actor start
+await Actor.charge({ eventName: 'actor-start' });
+
+if (!STANDBY_MODE) {
+    // If the Actor is not in standby mode, we should not run the MCP server
+    const msg = 'This Actor is not meant to be run directly. It should be run in standby mode.';
+    log.error(msg);
+    await Actor.exit({ statusMessage: msg });
+}
+
+await startServer({
+    serverPort: SERVER_PORT,
+    command: MCP_COMMAND,
+});

--- a/wolfram-mcp-server/src/mcp.ts
+++ b/wolfram-mcp-server/src/mcp.ts
@@ -1,0 +1,158 @@
+/**
+ * This module provides functions to create and manage an MCP server and its proxy client.
+ * It registers protocol capabilities, request handlers, and notification handlers for the MCP server,
+ * and spawns a proxy client that communicates with another MCP process over stdio.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import {
+    ClientNotificationSchema,
+    ClientRequestSchema,
+    ResultSchema,
+    ServerNotificationSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { log } from 'apify';
+
+/**
+ * Creates and configures an MCP server instance.
+ *
+ * - Registers all protocol capabilities except experimental.
+ * - Spawns a proxy client to forward requests and notifications.
+ * - Sets up handlers for requests and notifications between the server and proxy client.
+ * - Handles server shutdown and proxy client cleanup.
+ *
+ * @param command - The command to start the MCP proxy process.
+ * @param options - Optional configuration (e.g., request timeout).
+ * @returns A Promise that resolves to a configured McpServer instance.
+ */
+export async function getMcpServer(
+    command: string[],
+    options?: {
+        timeout?: number;
+    },
+): Promise<McpServer> {
+    // Create the MCP server instance
+    const server = new McpServer({
+        name: 'mcp-server',
+        version: '1.0.0',
+    });
+
+    // Register all capabilities except experimental
+    server.server.registerCapabilities({
+        tools: {},
+        prompts: {},
+        resources: {},
+        completions: {},
+        logging: {},
+        tasks: {},
+    });
+
+    // Spawn MCP proxy client for the stdio MCP server
+    const proxyClient = await getMcpProxyClient(command);
+
+    // Register request handlers for all client requests
+    for (const schema of ClientRequestSchema.options) {
+        const method = schema.shape.method.value;
+        // Forward requests to the proxy client and return its response
+        server.server.setRequestHandler(schema, async (req) => {
+            if (req.method === 'initialize') {
+                // Handle the 'initialize' request separately and do not forward it to the proxy client
+                // this is needed for mcp-remote servers to work correctly
+                return {
+                    capabilities: proxyClient.getServerCapabilities(),
+                    // Return back the client protocolVersion
+                    protocolVersion: req.params.protocolVersion,
+                    serverInfo: {
+                        name: 'Apify MCP proxy server',
+                        title: 'Apify MCP proxy server',
+                        version: '1.0.0',
+                    },
+                };
+            }
+            log.info('Received MCP request', {
+                method,
+                request: req,
+            });
+            return proxyClient.request(req, ResultSchema, {
+                timeout: options?.timeout || DEFAULT_REQUEST_TIMEOUT_MSEC,
+            });
+        });
+    }
+
+    // Register notification handlers for all client notifications
+    for (const schema of ClientNotificationSchema.options) {
+        const method = schema.shape.method.value;
+        // Forward notifications to the proxy client
+        server.server.setNotificationHandler(schema, async (notification) => {
+            if (notification.method === 'notifications/initialized') {
+                // Do not forward the 'notifications/initialized' notification
+                // This is needed for mcp-remote servers to work correctly
+                return;
+            }
+            log.info('Received MCP notification', {
+                method,
+                notification,
+            });
+            await proxyClient.notification(notification);
+        });
+    }
+
+    // Register notification handlers for all proxy client notifications
+    for (const schema of ServerNotificationSchema.options) {
+        const method = schema.shape.method.value;
+        // Forward notifications from the proxy client to the server
+        proxyClient.setNotificationHandler(schema, async (notification) => {
+            log.info('Sending MCP notification', {
+                method,
+                notification,
+            });
+            await server.server.notification(notification);
+        });
+    }
+
+    // Handle server shutdown and cleanup proxy client
+    server.server.onclose = () => {
+        log.info('MCP Server is closing, shutting down the proxy client');
+        proxyClient.close().catch((error) => {
+            log.error('Error closing MCP Proxy Client', {
+                error,
+            });
+        });
+    };
+
+    return server;
+}
+
+/**
+ * Creates and connects an MCP Proxy Client using a given command.
+ *
+ * This function splits the provided command string into the executable and its arguments,
+ * initializes a StdioClientTransport for communication, and then creates a Client instance.
+ * It connects the client to the transport and returns the connected client.
+ *
+ * @param command - The command to start the MCP proxy process (e.g., 'node server.js').
+ * @returns A Promise that resolves to a connected Client instance.
+ */
+export async function getMcpProxyClient(command: string[]): Promise<Client> {
+    log.info('Starting MCP Proxy Client', {
+        command,
+    });
+    // Create a stdio transport for the proxy client
+    const transport = new StdioClientTransport({
+        command: command[0],
+        args: command.slice(1),
+    });
+
+    // Create the MCP proxy client instance
+    const client = new Client({
+        name: 'mcp-proxy-client',
+        version: '1.0.0',
+    });
+
+    // Connect the client to the transport
+    await client.connect(transport);
+    log.info('MCP Proxy Client started successfully');
+    return client;
+}

--- a/wolfram-mcp-server/src/server.ts
+++ b/wolfram-mcp-server/src/server.ts
@@ -1,0 +1,259 @@
+/**
+ * This module implements the HTTP server for the MCP protocol.
+ * It manages session-based transports, request routing, and billing for protocol messages.
+ *
+ * The server supports streamable HTTP endpoints and handles session
+ * initialization, message routing, and resource cleanup on shutdown.
+ */
+import { randomUUID } from 'node:crypto';
+
+import { InMemoryEventStore } from '@modelcontextprotocol/sdk/examples/shared/inMemoryEventStore.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { log } from 'apify';
+import type { Request, Response } from 'express';
+import express from 'express';
+
+import { chargeMessageRequest } from './billing.js';
+import { getMcpServer as getMCPServerWithCommand } from './mcp.js';
+
+let getMcpServer: null | (() => Promise<McpServer>) = null;
+
+// Map to store transports by session ID
+const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
+
+/**
+ * Handles POST requests to the /mcp endpoint.
+ * - Initializes new sessions and transports if needed.
+ * - Routes requests to the correct transport based on session ID.
+ * - Charges for each message request.
+ */
+async function mcpPostHandler(req: Request, res: Response) {
+    // Ensure the MCP server is initialized
+    if (!getMcpServer) {
+        res.status(500).json({
+            jsonrpc: '2.0',
+            error: {
+                code: -32000,
+                message: 'Server not initialized',
+            },
+            id: null,
+        });
+        return;
+    }
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    log.info('Received MCP request', {
+        sessionId: sessionId || null,
+        body: req.body,
+    });
+    try {
+        let transport: StreamableHTTPServerTransport;
+        if (sessionId && transports[sessionId]) {
+            // Reuse existing transport for the session
+            transport = transports[sessionId] as StreamableHTTPServerTransport;
+        } else if (!sessionId && isInitializeRequest(req.body)) {
+            // New initialization request: create a new transport and event store
+            const eventStore = new InMemoryEventStore();
+            transport = new StreamableHTTPServerTransport({
+                sessionIdGenerator: () => randomUUID(),
+                eventStore, // Enable resumability
+                onsessioninitialized: (initializedSessionId) => {
+                    // Store the transport by session ID when session is initialized
+                    // This avoids race conditions where requests might come in before the session is stored
+                    log.info('Session initialized', {
+                        sessionId: initializedSessionId,
+                    });
+                    transports[initializedSessionId] = transport;
+                },
+            });
+
+            // Charge for each message request received on this transport
+            transport.onmessage = (message) => {
+                chargeMessageRequest(message as { method: string }).catch((error) => {
+                    log.error('Error charging for message request:', {
+                        error,
+                        sessionId: transport.sessionId || null,
+                    });
+                });
+            };
+
+            // Clean up transport when closed
+            transport.onclose = () => {
+                const sid = transport.sessionId;
+                if (sid && transports[sid]) {
+                    log.info('Transport closed', {
+                        sessionId: sid,
+                    });
+                    delete transports[sid];
+                }
+            };
+
+            // Connect the transport to the MCP server BEFORE handling the request
+            // so responses can flow back through the same transport
+            const server = await getMcpServer();
+            await server.connect(transport);
+
+            await transport.handleRequest(req, res, req.body);
+            return; // Already handled
+        } else {
+            // Invalid request - no session ID or not initialization request
+            res.status(400).json({
+                jsonrpc: '2.0',
+                error: {
+                    code: -32000,
+                    message: 'Bad Request: No valid session ID provided',
+                },
+                id: null,
+            });
+            return;
+        }
+
+        // Handle the request with existing transport - no need to reconnect
+        // The existing transport is already connected to the server
+        await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+        log.error('Error handling MCP request:', {
+            error,
+            sessionId: sessionId || null,
+        });
+        if (!res.headersSent) {
+            res.status(500).json({
+                jsonrpc: '2.0',
+                error: {
+                    code: -32603,
+                    message: 'Internal server error',
+                },
+                id: null,
+            });
+        }
+    }
+}
+
+/**
+ * Handles GET requests to the /mcp endpoint for streaming responses.
+ * - Validates session ID and resumes or establishes SSE streams as needed.
+ */
+async function mcpGetHandler(req: Request, res: Response) {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    if (!sessionId || !transports[sessionId]) {
+        res.status(400).send('Invalid or missing session ID');
+        return;
+    }
+
+    // Check for Last-Event-ID header for resumability
+    const lastEventId = req.headers['last-event-id'] as string | undefined;
+    if (lastEventId) {
+        log.info('Client reconnecting', {
+            lastEventId: lastEventId || null,
+        });
+    } else {
+        log.info('Establishing new SSE stream', {
+            sessionId: sessionId || null,
+        });
+    }
+
+    const transport = transports[sessionId] as StreamableHTTPServerTransport;
+    await transport.handleRequest(req, res);
+}
+
+/**
+ * Handles DELETE requests to the /mcp endpoint for session termination.
+ * - Cleans up and closes the transport for the given session.
+ */
+async function mcpDeleteHandler(req: Request, res: Response) {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    if (!sessionId || !transports[sessionId]) {
+        res.status(400).send('Invalid or missing session ID');
+        return;
+    }
+
+    log.info('Received session termination request', {
+        sessionId: sessionId || null,
+    });
+
+    try {
+        const transport = transports[sessionId] as StreamableHTTPServerTransport;
+        await transport.handleRequest(req, res);
+    } catch (error) {
+        log.error('Error handling session termination:', {
+            error,
+        });
+        if (!res.headersSent) {
+            res.status(500).send('Error processing session termination');
+        }
+    }
+}
+
+/**
+ * Starts the MCP HTTP server and sets up all endpoints.
+ * - Initializes the MCP server factory.
+ * - Registers all HTTP endpoints.
+ * - Handles graceful shutdown and resource cleanup.
+ */
+export async function startServer(options: { serverPort: number; command: string[] }) {
+    log.info('Starting MCP HTTP Server', {
+        serverPort: options.serverPort,
+        command: options.command,
+    });
+    const { serverPort, command } = options;
+    // Initialize the MCP client
+    getMcpServer = async () => getMCPServerWithCommand(command);
+
+    const app = express();
+
+    // Redirect to Apify favicon
+    app.get('/favicon.ico', (_req: Request, res: Response) => {
+        res.writeHead(301, { Location: 'https://apify.com/favicon.ico' });
+        res.end();
+    });
+
+    // Readiness probe handler
+    app.get('/', (req: Request, res: Response) => {
+        if (req.headers['x-apify-container-server-readiness-probe']) {
+            log.info('Readiness probe');
+            res.end('ok\n');
+            return;
+        }
+        res.status(404).end();
+    });
+
+    // Return the Apify OAuth authorization server metadata to allow the MCP client to authenticate using OAuth
+    app.get('/.well-known/oauth-authorization-server', async (_req: Request, res: Response) => {
+        // Some MCP clients do not follow redirects, so we need to fetch the data and return it directly.
+        const response = await fetch(`https://api.apify.com/.well-known/oauth-authorization-server`);
+        const data = await response.json();
+        res.status(200).json(data);
+    });
+
+    app.use(express.json());
+
+    // Streamable HTTP endpoints
+    app.post('/mcp', mcpPostHandler);
+    app.get('/mcp', mcpGetHandler);
+    app.delete('/mcp', mcpDeleteHandler);
+
+    app.listen(serverPort, () => {
+        log.info(`MCP HTTP Server listening on port ${serverPort}`);
+    });
+
+    // Handle server shutdown
+    process.on('SIGINT', async () => {
+        log.info('Shutting down server...');
+
+        // Close all active transports to properly clean up resources
+        for (const sessionId of Object.keys(transports)) {
+            try {
+                log.info(`Closing transport for session ${sessionId}`);
+                await transports[sessionId].close();
+                delete transports[sessionId];
+            } catch (error) {
+                log.error(`Error closing transport for session ${sessionId}:`, {
+                    error,
+                });
+            }
+        }
+        log.info('Server shutdown complete');
+        process.exit(0);
+    });
+}

--- a/wolfram-mcp-server/test/main.test.ts
+++ b/wolfram-mcp-server/test/main.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest';
+
+describe('Example test', () => {
+    it('works', () => {
+        expect(1 + 1).toBe(2);
+    });
+});

--- a/wolfram-mcp-server/tsconfig.json
+++ b/wolfram-mcp-server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "extends": "@apify/tsconfig",
+    "compilerOptions": {
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "target": "ES2022",
+        "outDir": "dist",
+        "rootDir": "./src",
+        "incremental": false,
+        "noUnusedLocals": false,
+        "skipLibCheck": true,
+        "lib": ["DOM"]
+    },
+    "include": ["./src/**/*"]
+}


### PR DESCRIPTION
slack context: https://apify.slack.com/archives/C04URRT3934/p1778591698674219

## Context
Adds the Wolfram MCP Server as a new Actor in this monorepo, wrapping [Wolfram's hosted MCP service](https://www.wolfram.com/artificial-intelligence/mcp-service/) so it can be deployed and monetized via Apify.

## Solution
TypeScript proxy Actor (same pattern as `microsoft-learn-mcp-server` / `exa-mcp-server`) that uses `mcp-remote` to forward to `https://services.wolfram.com/api/mcp` with `Authorization: Bearer $WOLFRAM_MCP_API_KEY`. Exposes the three upstream tools (`WolframContext`, `WolframLanguageEvaluator`, `WolframAlpha`) over a streamable HTTP endpoint.

## Worth your attention
- **Requires `WOLFRAM_MCP_API_KEY` secret** — added to `deploy_servers.sh` so the deploy script will inject it; the secret must exist in the deployer's `.env` / Apify secrets before `apify push`.
- **README + `actor.json` + `package.json`** were left as `ts-mcp-proxy` template defaults by the scaffolder — all three are now customized (title, description, name) to match the format of recent servers (microsoft-learn, tomtom).
- **Index entry** added to root `README.md` (table row + credits line) pointing at the `agentify/wolfram-mcp-server` store badge, matching existing convention.
